### PR TITLE
fix: remove logger import that causes pydantic env settings import

### DIFF
--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,1 +1,0 @@
-from .logging import LoggerConfigurator


### PR DESCRIPTION
Merging in discussion with @lennertjansen 